### PR TITLE
Add limit of before php 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.3.3,<7.0",
         "paragonie/random_compat": "~1.0|~2.0|~9.99"
     },
     "autoload": {


### PR DESCRIPTION
Add limit of before php 7.0 - so that the package does not install on systems that don't need it.